### PR TITLE
error handling 추가

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,19 @@
+import layoutStyles from '@/app/styles/layout.module.css';
+import styles from '@/app/styles/not-found.module.css';
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className={layoutStyles.page}>
+      <div className={styles.card}>
+        <div className={styles.content}>
+          <h1 className={styles.title}>Not Found</h1>
+          <p className={styles.description}>페이지를 찾을 수 없습니다. 🤔</p>
+          <Link href="/" className={styles.button}>
+            홈으로 돌아가기
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/question/error.tsx
+++ b/src/app/question/error.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import layoutStyles from '@/app/styles/layout.module.css';
+import styles from '@/app/styles/not-found.module.css';
+
+import { useEffect } from 'react';
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className={layoutStyles.page}>
+      <div className={styles.card}>
+        <div className={styles.content}>
+          <h2 className={styles.title}>문제가 생겼어요!</h2>
+          <p className={styles.description}>다시 시도해주세요. 😢</p>
+          <button className={styles.button} onClick={() => reset()}>
+            다시 시도하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/question/page.tsx
+++ b/src/app/question/page.tsx
@@ -22,6 +22,7 @@ export default function Question() {
 
   const {
     isLoading,
+    error,
     question,
     feedback,
     getTailQuestion,
@@ -29,6 +30,10 @@ export default function Question() {
     hasMoreQuestions,
     currentIndex,
   } = useQuestion(shuffleQuestion);
+
+  if (error) {
+    throw new Error(error);
+  }
 
   const getQuestionMessage = () => {
     if (!hasMoreQuestions) return '질문이 끝났습니다. 수고하셨습니다.';

--- a/src/app/styles/layout.module.css
+++ b/src/app/styles/layout.module.css
@@ -15,6 +15,7 @@
   color: var(--color-blue300);
   padding: 0 16px;
   margin-bottom: 20px;
+  gap: 5px;
 }
 
 .list {

--- a/src/app/styles/not-found.module.css
+++ b/src/app/styles/not-found.module.css
@@ -1,0 +1,36 @@
+.card {
+  padding: 20px;
+  margin: auto 20px;
+  border-radius: 10px;
+  box-shadow: 5px 5px 4px var(--color-gray100);
+  background-color: var(--color-background-light);
+  cursor: pointer;
+}
+
+.content {
+  height: 300px;
+  color: var(--color-blue300);
+  gap: 5px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.title {
+  font-size: 45px;
+}
+
+.description {
+  font-size: 20px;
+}
+
+.button {
+  padding: 10px 20px;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  margin-top: 50px;
+  color: white;
+  background-color: var(--color-blue300);
+}

--- a/src/app/styles/not-found.module.css
+++ b/src/app/styles/not-found.module.css
@@ -27,6 +27,7 @@
 
 .button {
   padding: 10px 20px;
+  font-size: 16px;
   border: none;
   border-radius: 10px;
   cursor: pointer;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#18

## ✏️ 작업 내용
- [nextjs/error-handling](https://nextjs.org/docs/app/building-your-application/routing/error-handling)
- error.tsx, not-found.tsx 구현

<img width="50%" alt="스크린샷 2025-01-12 오후 4 55 00" src="https://github.com/user-attachments/assets/eb031a06-ecd6-4327-b4fd-18454a2b3f8c" /><img width="50%" alt="스크린샷 2025-01-12 오후 4 54 52" src="https://github.com/user-attachments/assets/27413a18-a033-40f4-ba6b-0f1e15ec8e5e" />

## 🎸 기타사항
- next 문서에서 `import Error from 'next/error'`를 사용해 404, 500 에러 처리를 커스텀하는 글을 보고 
not-found와 차이점을 찾아봤는데, Pages Router에서 사용되던 방식이라고 하더라고요.
  현재 사용되는 App router를 권장하며 에러 헨들링에 error.js, not-found.js, notFound()를 사용한다고 합니다.