### PR TITLE
주제와 질문이 맞지 않는 문제 수정

### DIFF
--- a/src/app/(routes)/question/page.tsx
+++ b/src/app/(routes)/question/page.tsx
@@ -18,7 +18,7 @@ export default function Question() {
   const questionList =
     contents === 'all' ? topicContents : contents?.split(',');
 
-  const shuffleQuestion = shuffleArray(questionList || []);
+  const shuffledQuestions = useRef(shuffleArray(questionList || []));
 
   const {
     isLoading,
@@ -29,7 +29,9 @@ export default function Question() {
     getNextQuestion,
     hasMoreQuestions,
     currentIndex,
-  } = useQuestion(shuffleQuestion);
+  } = useQuestion(shuffledQuestions.current);
+
+  const topic = shuffledQuestions.current[currentIndex];
 
   if (error) {
     throw new Error(error);
@@ -65,7 +67,7 @@ export default function Question() {
       </header>
       <main className={styles.question}>
         <QuestionFeedbackSwitcher
-          topic={shuffleQuestion[currentIndex] || '면접 종료'}
+          topic={topic || '면접 종료'}
           question={getQuestionMessage()}
           onNextTopic={getNextQuestion}
           feedback={feedback}

--- a/src/components/QuestionFeedbackSwitcher/QuestionFeedbackSwitcher.tsx
+++ b/src/components/QuestionFeedbackSwitcher/QuestionFeedbackSwitcher.tsx
@@ -25,7 +25,7 @@ export default function QuestionFeedbackSwitcher({
     if (!isEmptyFeedback) {
       setVisible(true);
     }
-  }, [isEmptyFeedback]);
+  }, [isEmptyFeedback, feedback]);
 
   return (
     <div>

--- a/src/hooks/useQuestion.ts
+++ b/src/hooks/useQuestion.ts
@@ -55,7 +55,7 @@ export function useQuestion(keywords: string[]) {
 
   useEffect(() => {
     generateQuestion();
-  }, []);
+  }, [currentIndex]);
 
   return {
     isLoading,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#34 

## ✏️ 작업 내용

- 주제 셔플이 두번 돼서 셔플 변수 ref로 감싸 수정
- 다음 주제 클릭 시 주제만 바뀌고 질문이 바뀌지 않는 문제로 문제를 가져오는 useEffect 의존성 배열에 current index 추가
- 답변을 제출하면 매번 바로 피드백 카드가 보이게 의존성 배열에 피드백 추가

## 🎸 기타사항
