### PR TITLE
packageManager 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "my-app",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@9.14.4",
   "scripts": {
     "dev": "next dev",
     "build": "next build",


### PR DESCRIPTION
## #️⃣ 연관된 이슈

## ✏️ 작업 내용
- package.json에 packageManager 추가

<img width="755" alt="스크린샷 2025-01-16 오후 5 46 02" src="https://github.com/user-attachments/assets/247dfe71-acd6-4eca-ac8e-46958f211a08" />

- install command에 pnpm install을 오버라이드로 입력하면 가장 오래된 버전으로 들어가서 
package.json에 `"packageManager": "pnpm@9.14.4"` packageManager을 추가해 사용하는 pnpm 버전을 추가해주고, 
key에 `ENABLE_EXPERIMENTAL_COREPACK=1`를 추가해줘야했다.

## 🎸 기타사항
- https://vercel.com/docs/deployments/builds/package-managers
- https://vercel.com/changelog/corepack-experimental-is-now-available
- https://jelaniharris.com/blog/fixing-errinvalidthis-error-on-vercel-using-pnpm/